### PR TITLE
[FEAT] #13 게시글 상세 페이지 내 참여신청, 댓글 관리 및 이미지 업로드 처리

### DIFF
--- a/src/app/posts/write/FileInput.tsx
+++ b/src/app/posts/write/FileInput.tsx
@@ -18,6 +18,13 @@ export default function FileInput({ files, setFiles }: FileInputProps) {
     const validFiles: File[] = [];
 
     for (const file of Array.from(selectedFiles)) {
+      const isDuplicate = files.some((f) => f.name === file.name); // 이미 같은 이름의 파일이 있는지 확인
+
+      if (isDuplicate) {
+        alert(`이미 '${file.name}' 파일이 추가되어 있습니다.`);
+        continue;
+      }
+
       if (validateFile(file)) {
         console.log(`유효한 파일: ${file.name}`);
         validFiles.push(file);
@@ -32,7 +39,7 @@ export default function FileInput({ files, setFiles }: FileInputProps) {
     }
 
     // // 동일 파일 다시 선택 가능하게 초기화
-    // e.target.value = "";
+    e.target.value = "";
   };
 
   const handleDelete = (name: string) => {

--- a/src/components/comments/CommentItem.tsx
+++ b/src/components/comments/CommentItem.tsx
@@ -1,8 +1,40 @@
+"use client";
+
+import { useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card } from "../ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { Comment } from "@/types/comment";
+import { ConfirmDialog } from "@/app/participation/Alertmessage";
 
 const CommentItem = ({ comment }: { comment: Comment }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedContent, setEditedContent] = useState(comment.content);
+  const [currentContent, setCurrentContent] = useState(comment.content);
+  const [isDeleted, setIsDeleted] = useState(false);
+
+  const handleSave = () => {
+    // 수정 저장 API 호출
+    console.log("수정된 내용:", editedContent);
+    setCurrentContent(editedContent);
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setEditedContent(currentContent);
+    setIsEditing(false);
+  };
+
+  const handleDelete = () => {
+    // 삭제 API 호출
+    console.log("댓글 삭제됨:", comment.id);
+    setIsDeleted(true);
+  };
+
+  if (isDeleted) return null;
+
   return (
     <Card className="p-4 mb-4 bg-white">
       <div className="flex items-center gap-2">
@@ -15,7 +47,55 @@ const CommentItem = ({ comment }: { comment: Comment }) => {
           <p className="text-sm text-black">{comment.createdAt}</p>
         </div>
       </div>
-      <p className="mt-2 text-black">{comment.content}</p>
+
+      {isEditing ? (
+        <Textarea
+          className="mt-2 text-black"
+          value={editedContent}
+          onChange={(e) => setEditedContent(e.target.value)}
+        />
+      ) : (
+        <p className="mt-2 text-black">{currentContent}</p>
+      )}
+
+      <div className="flex justify-end gap-2">
+        {isEditing ? (
+          <>
+            <Button size="sm" variant="default" onClick={handleSave}>
+              저장
+            </Button>
+            <Button size="sm" variant="secondary" onClick={handleCancel}>
+              취소
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="text-sm text-gray-40 hover:text-gray-50"
+              onClick={() => setIsEditing(true)}
+            >
+              수정하기
+            </Button>
+
+            <ConfirmDialog
+              trigger={
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="text-sm text-gray-40 hover:text-gray-50"
+                >
+                  삭제하기
+                </Button>
+              }
+              title="댓글을 삭제하시겠습니까?"
+              description="삭제된 댓글은 복구할 수 없습니다."
+              onConfirm={handleDelete}
+            />
+          </>
+        )}
+      </div>
     </Card>
   );
 };

--- a/src/components/posts/JoinProfileCard.tsx
+++ b/src/components/posts/JoinProfileCard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Card, CardContent } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Post } from "@/types/post";
@@ -8,10 +8,13 @@ import { AvatarImage } from "@radix-ui/react-avatar";
 import { Member } from "@/types/user";
 import { Calendar, MapPin, Shapes, Users } from "lucide-react";
 import { ConfirmDialog } from "@/app/participation/Alertmessage";
+import { useState } from "react";
 
 const JoinProfileCard = ({ post }: { post: Post }) => {
+  const [applied, setApplied] = useState(false);
   const handleApply = () => {
     console.log("참여 신청 완료!");
+    setApplied(true);
   };
 
   return (
@@ -48,18 +51,25 @@ const JoinProfileCard = ({ post }: { post: Post }) => {
         <Badge>{post.categoryName}</Badge>
       </div>
       <div className="flex justify-center">
-        <ConfirmDialog
-          trigger={
-            <Button variant="default" className="flex w-[80%] mb-2">
-              참여 신청하기
-            </Button>
-          }
-          title="참여 신청하시겠습니까?"
-          description="이 모임에 참여를 신청합니다."
-          onConfirm={handleApply}
-        />
+        {applied ? (
+          <Button disabled className="flex w-[80%] mb-2 bg-gray-300 cursor-not-allowed">
+            신청 완료
+          </Button>
+        ) : (
+          <ConfirmDialog
+            trigger={
+              <Button variant="default" className="flex w-[80%] mb-2">
+                참여 신청하기
+              </Button>
+            }
+            title="참여 신청하시겠습니까?"
+            description="신청 후 주최자의 승인을 기다려야 합니다."
+            onConfirm={handleApply}
+          />
+        )}
       </div>
     </Card>
   );
 };
+
 export default JoinProfileCard;

--- a/src/components/posts/JoinProfileCard.tsx
+++ b/src/components/posts/JoinProfileCard.tsx
@@ -1,4 +1,5 @@
-import { Card } from "@/components/ui/card";
+"use client";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Post } from "@/types/post";
@@ -6,8 +7,13 @@ import { Avatar, AvatarFallback } from "../ui/avatar";
 import { AvatarImage } from "@radix-ui/react-avatar";
 import { Member } from "@/types/user";
 import { Calendar, MapPin, Shapes, Users } from "lucide-react";
+import { ConfirmDialog } from "@/app/participation/Alertmessage";
 
 const JoinProfileCard = ({ post }: { post: Post }) => {
+  const handleApply = () => {
+    console.log("참여 신청 완료!");
+  };
+
   return (
     <Card className="p-4 w-full rounded-xl text-sm bg-white gap-2">
       <div className="flex items-center gap-2">
@@ -42,12 +48,18 @@ const JoinProfileCard = ({ post }: { post: Post }) => {
         <Badge>{post.categoryName}</Badge>
       </div>
       <div className="flex justify-center">
-        <Button variant="default" className="flex w-[80%] mb-2 ">
-          참여 신청하기
-        </Button>
+        <ConfirmDialog
+          trigger={
+            <Button variant="default" className="flex w-[80%] mb-2">
+              참여 신청하기
+            </Button>
+          }
+          title="참여 신청하시겠습니까?"
+          description="이 모임에 참여를 신청합니다."
+          onConfirm={handleApply}
+        />
       </div>
     </Card>
   );
 };
-
 export default JoinProfileCard;

--- a/src/components/posts/JoinProfileCard.tsx
+++ b/src/components/posts/JoinProfileCard.tsx
@@ -11,13 +11,13 @@ const JoinProfileCard = ({ post }: { post: Post }) => {
   return (
     <Card className="p-4 w-full rounded-xl text-sm bg-white gap-2">
       <div className="flex items-center gap-2">
-        <Avatar className="w-24 h-24">
+        <Avatar className="w-20 h-20">
           <AvatarImage src="/public/images/cat.jpg" />
           <AvatarFallback>{post.userName}</AvatarFallback>
         </Avatar>
         <div>
           <div className="pl-2 pt-2 text-lg font-semibold mb-2">{post.userName}</div>
-          <p className="text-sm text-gray-500">2001.01.08</p>
+          {/* <p className="text-sm text-gray-500">2001.01.08</p> */}
         </div>
       </div>
       <div className="flex items-center gap-2 text-sm text-gray-50 mt-2">
@@ -26,7 +26,9 @@ const JoinProfileCard = ({ post }: { post: Post }) => {
       </div>
       <div className="flex items-center gap-2 text-sm text-gray-50 mt-2">
         <Users className="w-4 h-4" />
-        <span>{post.location}</span>
+        <span>
+          {post.currentParticipants} / {post.maxParticipants}
+        </span>
       </div>
       <div className="flex items-center gap-2 text-sm text-gray-50 mt-2">
         <MapPin className="w-4 h-4" />

--- a/src/components/posts/PostDetailItem.tsx
+++ b/src/components/posts/PostDetailItem.tsx
@@ -85,7 +85,7 @@ const PostDetailItem = ({ post }: { post: Post }) => {
           {post.location}
         </div>
         <div>
-          <span className="font-semibold">모집 마감</span>
+          <span className="font-semibold">모집 상태</span>
           <br />
           {post.status}
         </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -19,7 +19,7 @@ const buttonVariants = cva(
 
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
-        ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        ghost: " hover:text-gray-600",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/src/types/comment.ts
+++ b/src/types/comment.ts
@@ -1,4 +1,5 @@
 export interface Comment {
+  id: string;
   userName: string;
   profileImg?: string;
   content: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13 

## 📝작업 내용

> 참여 신청 버튼 클릭시 다이얼로그 설정 및 버튼 스타일 변경
이미지 업로드시 중복 파일 선택 제한
댓글 수정 삭제 관련 구현

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
